### PR TITLE
Let local_port default to remote_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Create ~/.tunneler.cfg or tunnels.cfg with something similar to this:
 	# This translates to ssh -g -f -N -L{local_port}:{host}:{remote_port} {user}@{server}
 	[TUNNEL-NAME]
 	name = TUNNEL_LONG_NAME
-	local_port = LOCAL_MACHINE_PORT
+	local_port = LOCAL_MACHINE_PORT # defaults to remote_port
 	remote_port = SERVER_PORT
 	server = SERVER_NAME
 	user = OPTIONAL_USER_NAME # defaults to common's default_user

--- a/tunneler.cfg.sample
+++ b/tunneler.cfg.sample
@@ -19,7 +19,7 @@ tunnel_group_1 =
 # This translates to ssh -g -f -N -L{local_port}:{host}:{remote_port} {user}@{server}
 [TUNNEL-NAME]
 name = TUNNEL_LONG_NAME
-local_port = LOCAL_MACHINE_PORT
+local_port = LOCAL_MACHINE_PORT # defaults to remote_port
 remote_port = SERVER_PORT
 server = SERVER_NAME
 user = OPTIONAL_USER_NAME # defaults to common's default_user

--- a/tunneler/tests/test_tunneler.py
+++ b/tunneler/tests/test_tunneler.py
@@ -199,6 +199,17 @@ class TunnelerTestCase(TestCase):
         with self.assertRaises(NameError):
             self.tunneler.get_active_tunnel('idonotexist')
 
+    def test_use_remote_port_when_local_port_not_in_config(self):
+        del self.config.tunnels[self.tunnel_name]['local_port']
+        self.assertIsNone(
+            self.config.tunnels[self.tunnel_name].get('local_port')
+        )
+        tunneler = Tunneler(self.process_helper, self.config)
+        self.assertEqual(
+            tunneler.config.tunnels[self.tunnel_name]['local_port'],
+            tunneler.config.tunnels[self.tunnel_name]['remote_port']
+        )
+
     def test_is_tunnel_active(self):
         tunnel_config = {'server1': None, 'server2': None}
         self.tunneler.config = Configuration(

--- a/tunneler/tunneler.py
+++ b/tunneler/tunneler.py
@@ -33,8 +33,20 @@ class Tunneler(object):
     def __init__(self, process_helper, config, verbose=False, ssh_debug_level=0):
         self.process_helper = process_helper
         self.config = config
+        self._apply_defaults()
         self.verbose = verbose
         self.ssh_debug_level = ssh_debug_level
+
+    def _apply_defaults(self):
+        """
+        Mutate the config to apply default rules.
+
+        Return None.
+        """
+        for tunnel, info in self.config.tunnels.iteritems():
+            # Fall back to remote_port if local_port is not defined
+            if info.get('local_port', None) is None:
+                info['local_port'] = info['remote_port']
 
     def identify_tunnel(self, server, remote_port):
         """


### PR DESCRIPTION
Default to remote_port when local_port is not defined in the tunnel config.

The reason I do not put this rule in the `TunnelerConfigParser` is that it seems that object should be almost a one-to-one representation of the config file as it is on disk. The rule is then applied when we instantiate `Tunneler` which is the domain object where business rules should be.
Possible improvements could be to `config.copy()` instead of mutating the original config object. This would distinguish between config-as-on-disk and config-with-rules-applied.
We could also move the handling of configuration up a level and use it to drive the creation of the Tunneler object. 